### PR TITLE
Fix Function Indexes column not found error

### DIFF
--- a/src/include/columns.h
+++ b/src/include/columns.h
@@ -269,8 +269,7 @@ static bool parse_columns(const rapidjson::Value::ConstObject &dd_object,
     if (!check_columns(col)) return false;
     column_t column = add_column_to_map(col);
 
-    if (!is_column_hidden_user(column) && 
-        is_column_hidden(column)) return true; 
+    if (!is_column_hidden_user(column) && is_column_hidden(column)) continue;
 
     /* Column name - Required */
     if (!parse_column_attribute(col, ddl, "name")) return false;

--- a/test/test4_functional_index.sh
+++ b/test/test4_functional_index.sh
@@ -8,8 +8,8 @@ DATADIR=$(${MYSQL} ${MYSQL_ARGS} -NB -e "SELECT @@datadir")
 TABLE_NAME="test4_functional_index"
 
 
-echo "CREATE table test.${TABLE_NAME} (col1 LONGTEXT, INDEX idx1 ((SUBSTRING(col1, 1, 10))));" | ${MYSQL} ${MYSQL_ARGS}
-echo "INSERT INTO test.${TABLE_NAME} VALUES('foo');" | ${MYSQL} ${MYSQL_ARGS}
+echo "CREATE table test.${TABLE_NAME} (col1 LONGTEXT, col2 datetime DEFAULT NULL, INDEX idx1 ((SUBSTRING(col1, 1, 10))), INDEX idx2 ((cast(col2 as date))));" | ${MYSQL} ${MYSQL_ARGS}
+echo "INSERT INTO test.${TABLE_NAME} VALUES('foo', NOW());" | ${MYSQL} ${MYSQL_ARGS}
 innodb_wait_for_flush_all
 
 ${SUDO} ibd2sdi ${DATADIR}/test/${TABLE_NAME}.ibd | ${BASEDIR}/sdi2ddl > ${BASEDIR}/test/${TABLE_NAME}.sql
@@ -21,7 +21,7 @@ ${SUDO} cp ${DATADIR}/test/${TABLE_NAME}.ibd ${BASEDIR}/test/${TABLE_NAME}.ibd
 echo "UNLOCK TABLES;" >&3
 exec 3>&-
 
-echo "INSERT INTO test.${TABLE_NAME} VALUES('bar');" | ${MYSQL} ${MYSQL_ARGS}
+echo "INSERT INTO test.${TABLE_NAME} VALUES('bar', NOW());" | ${MYSQL} ${MYSQL_ARGS}
 echo "DROP TABLE test.${TABLE_NAME};" | ${MYSQL} ${MYSQL_ARGS}
 cat ${BASEDIR}/test/${TABLE_NAME}.sql | ${MYSQL} ${MYSQL_ARGS} test
 echo "ALTER TABLE test.${TABLE_NAME} DISCARD TABLESPACE;" | ${MYSQL} ${MYSQL_ARGS}


### PR DESCRIPTION
During column validation, we were wrongly exiting the column loop in case of a hidden column, while we should have skipped the current column and continue with the next one.

Closes #22 